### PR TITLE
Fix buffer overflow in storage component

### DIFF
--- a/TASTE_Integration/Native_Implementation/work/storage/implem/cfs/C/src/storage.c
+++ b/TASTE_Integration/Native_Implementation/work/storage/implem/cfs/C/src/storage.c
@@ -67,7 +67,7 @@ void storage_PI_Get
     *OUT_success = !is_empty();
     if (*OUT_success) {
         *OUT_out_data = box[next_out];
-        next_out = (next_out == BOX_CAPACITY) ? (0) : (next_out + 1);
+        next_out = (next_out == BOX_CAPACITY - 1) ? (0) : (next_out + 1);
         count = count - 1;
     }
 }
@@ -85,10 +85,10 @@ void storage_PI_Put
 {
    box[next_in] = *IN_in_data;
    last_in = next_in;
-   next_in = (next_in == BOX_CAPACITY -1) ? (0) : (next_in + 1);
+   next_in = (next_in == BOX_CAPACITY - 1) ? (0) : (next_in + 1);
    if (is_full()) {
        // overwrite last data
-       next_out = (next_out == BOX_CAPACITY -1) ? (0) : (next_out + 1);
+       next_out = (next_out == BOX_CAPACITY - 1) ? (0) : (next_out + 1);
    } else {
        count = count + 1;
    }

--- a/TASTE_Integration/Native_Implementation/work/storage/implem/cfs/C/src/storage.c
+++ b/TASTE_Integration/Native_Implementation/work/storage/implem/cfs/C/src/storage.c
@@ -85,10 +85,10 @@ void storage_PI_Put
 {
    box[next_in] = *IN_in_data;
    last_in = next_in;
-   next_in = (next_in == BOX_CAPACITY) ? (0) : (next_in + 1);
+   next_in = (next_in == BOX_CAPACITY -1) ? (0) : (next_in + 1);
    if (is_full()) {
        // overwrite last data
-       next_out = (next_out == BOX_CAPACITY) ? (0) : (next_out + 1);
+       next_out = (next_out == BOX_CAPACITY -1) ? (0) : (next_out + 1);
    } else {
        count = count + 1;
    }


### PR DESCRIPTION
Right now, storage is overflowing.
I found the problem is related to the count in next_in
We say box[next_in]. It has size 5 so should go 0,1,2,3,4,0,1,2,3,4 and repeat. However what is actually happening is 0,1,2,3,4,5 which leads to overflow and segmentation fault. To make it cyclic it has to be the size of the buffer - 1 